### PR TITLE
ForignKey Delete Bug Fix

### DIFF
--- a/src/migrations/2013_03_17_131246_verify_init.php
+++ b/src/migrations/2013_03_17_131246_verify_init.php
@@ -67,8 +67,8 @@ class VerifyInit extends Migration {
             $table->integer('role_id')->unsigned()->index();
             $table->timestamps();
 
-            $table->foreign('user_id')->references('id')->on($prefix.'users');
-            $table->foreign('role_id')->references('id')->on($prefix.'roles');
+            $table->foreign('user_id')->references('id')->on($prefix.'users')->onDelete('cascade');;
+            $table->foreign('role_id')->references('id')->on($prefix.'roles')->onDelete('cascade');;
         });
 
         // Create the permission/role relationship table
@@ -80,8 +80,8 @@ class VerifyInit extends Migration {
             $table->integer('role_id')->unsigned()->index();
             $table->timestamps();
 
-            $table->foreign('permission_id')->references('id')->on($prefix.'permissions');
-            $table->foreign('role_id')->references('id')->on($prefix.'roles');
+            $table->foreign('permission_id')->references('id')->on($prefix.'permissions')->onDelete('cascade');;
+            $table->foreign('role_id')->references('id')->on($prefix.'roles')->onDelete('cascade');;
         });
     }
 


### PR DESCRIPTION
When you delete a role~permission who has user or permission, 
it doesn't delete and throw error like this

```
SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails (`laravel`.`permission_role`, CONSTRAINT `permission_role_role_id_foreign` FOREIGN KEY (`role_id`) REFERENCES `roles` (`id`)) (SQL: delete from `roles` where `id` = 5)
```

this will fix that error
