### PR TITLE
Added has method to Role model to allow checking for permissions within a role

### DIFF
--- a/src/Toddish/Verify/Models/Role.php
+++ b/src/Toddish/Verify/Models/Role.php
@@ -44,4 +44,32 @@ class Role extends BaseModel
             )
         ->withTimestamps();
     }
+
+    /**
+     * Does the role have a specific permission
+     *
+     * @param  array|string $permissions Single permission or an array of permissions
+     * @return boolean
+     */
+    public function has( $permissions )
+    {
+        $permissions = !is_array($permissions)
+            ? array($permissions)
+            : $permissions;
+
+        $valid = false;
+
+        foreach (static::permissions()->get() as $permission)
+        {
+            foreach ($permissions as $perm_to_check) {
+                if( $permission->name == $perm_to_check )
+                {
+                    $valid = true;
+                    break 1;
+                }
+            }
+        }
+
+        return $valid;
+    }
 }


### PR DESCRIPTION
I've added a has method within the Role model to allow checks on the permission name to see if the role has that specific permission. Very handy for creating a role/permission admin screen, etc.
