### PR TITLE
Added != (is not) modifier to the level method

### DIFF
--- a/src/Toddish/Verify/Models/User.php
+++ b/src/Toddish/Verify/Models/User.php
@@ -218,7 +218,7 @@ class User extends BaseModel implements UserInterface, RemindableInterface
                 break;
 
             case '!=':
-                return $role->level != $level;
+                return !in_array($level, $levels);
                 break;
 
             default:


### PR DESCRIPTION
Added `!=` (is not)  modifier to the `level` method to check if a user does not have a level of `$level`
