### PR TITLE
'Str' facade/alias no longer included by default in L5

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -5,7 +5,8 @@ use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract,
 	Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract,
 	Illuminate\Database\Eloquent\SoftDeletes,
 	Illuminate\Auth\Authenticatable,
-	Illuminate\Auth\Passwords\CanResetPassword;
+	Illuminate\Auth\Passwords\CanResetPassword,
+	Illuminate\Support\Str;
 
 class User extends BaseModel implements AuthenticatableContract, CanResetPasswordContract
 {
@@ -36,7 +37,7 @@ class User extends BaseModel implements AuthenticatableContract, CanResetPasswor
 
 	public function setPasswordAttribute($password)
 	{
-		$salt = md5(\Str::random(64) . time());
+		$salt = md5(Str::random(64) . time());
 
 		$this->attributes['password'] = \Hash::make($salt . $password);
 		$this->attributes['salt'] = $salt;


### PR DESCRIPTION
Noticed this one on a new L5 Project.

Other option would be to use the helper method str_random(64).